### PR TITLE
IDEX-1497. Fixed: Git history menu is inactive after opening a project i...

### DIFF
--- a/codenvy-ext-git/src/main/java/com/codenvy/ide/ext/git/client/action/HistoryAction.java
+++ b/codenvy-ext-git/src/main/java/com/codenvy/ide/ext/git/client/action/HistoryAction.java
@@ -49,6 +49,6 @@ public class HistoryAction extends GitAction {
     @Override
     public void update(ActionEvent e) {
         e.getPresentation().setVisible(getActiveProject() != null);
-        e.getPresentation().setEnabled(isGitRepository() && isItemSelected());
+        e.getPresentation().setEnabled(isGitRepository());
     }
 }


### PR DESCRIPTION
IDEX-1497. Fixed: Git history menu is inactive after opening a project if user haven't clicked in project explorer.
